### PR TITLE
Message security

### DIFF
--- a/client/src/components/ChatBubble.css
+++ b/client/src/components/ChatBubble.css
@@ -30,6 +30,7 @@
   border-radius: 10pt;
   padding: 5pt;
 }
- .time {
-   margin: 0;
- }
+
+.time {
+  margin: 0;
+}

--- a/client/src/components/ChatBubble.js
+++ b/client/src/components/ChatBubble.js
@@ -9,12 +9,13 @@ import { useAuthState } from 'react-firebase-hooks/auth';
 // TODO: Move into a DB controller API.
 export async function fetchUserData(uid) {
     const userRef = await getDoc(doc(db, "users", uid));
+    if (!userRef) throw new Error('uid not found.')
     return userRef.data();
 }
 
 export async function fetchUsername(uid) {
     const userData = await fetchUserData(uid);
-    return userData.username;
+    return userData?.username;
 }
 
 export default function ChatBubble(props)  {

--- a/client/src/components/ChatOptions.js
+++ b/client/src/components/ChatOptions.js
@@ -1,0 +1,10 @@
+import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from '@mui/material';
+import React from 'react';
+
+export default function ChatOptions(props) {
+  return (<Button>
+    <FontAwesomeIcon icon={faEllipsisV}/>
+  </Button>)
+}

--- a/client/src/components/ChatSettingsButton.js
+++ b/client/src/components/ChatSettingsButton.js
@@ -11,11 +11,15 @@ export default function ChatSettingsButton(props) {
     setOpen(true);
   }
 
+  function handleClose() {
+    setOpen(false);
+  }
+
   return (<>
     <Button onClick={handleClick}>
       <FontAwesomeIcon icon={faEllipsisV}/>
     </Button>
-    <Dialog open={open}>
+    <Dialog open={open} onClose={handleClose}>
       <ChatSettingsForm/>
     </Dialog>
   </>)

--- a/client/src/components/ChatSettingsButton.js
+++ b/client/src/components/ChatSettingsButton.js
@@ -1,10 +1,16 @@
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button } from '@mui/material';
+import { Button, Dialog } from '@mui/material';
 import React from 'react';
+import ChatSettingsForm from './ChatSettingsForm';
 
 export default function ChatSettingsButton(props) {
-  return (<Button>
-    <FontAwesomeIcon icon={faEllipsisV}/>
-  </Button>)
+  return (<>
+    <Button>
+      <FontAwesomeIcon icon={faEllipsisV}/>
+    </Button>
+    <Dialog>
+      <ChatSettingsForm/>
+    </Dialog>
+  </>)
 }

--- a/client/src/components/ChatSettingsButton.js
+++ b/client/src/components/ChatSettingsButton.js
@@ -3,7 +3,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@mui/material';
 import React from 'react';
 
-export default function ChatOptions(props) {
+export default function ChatSettingsButton(props) {
   return (<Button>
     <FontAwesomeIcon icon={faEllipsisV}/>
   </Button>)

--- a/client/src/components/ChatSettingsButton.js
+++ b/client/src/components/ChatSettingsButton.js
@@ -5,6 +5,8 @@ import React, { useState } from 'react';
 import ChatSettingsForm from './ChatSettingsForm';
 
 export default function ChatSettingsButton(props) {
+  const {conversationRef: currentConversationRef} = props;
+  
   const [open, setOpen] = useState(false);
 
   function handleClick() {
@@ -20,7 +22,7 @@ export default function ChatSettingsButton(props) {
       <FontAwesomeIcon icon={faEllipsisV}/>
     </Button>
     <Dialog open={open} onClose={handleClose}>
-      <ChatSettingsForm/>
+      <ChatSettingsForm conversationRef={currentConversationRef}/>
     </Dialog>
   </>)
 }

--- a/client/src/components/ChatSettingsButton.js
+++ b/client/src/components/ChatSettingsButton.js
@@ -1,15 +1,21 @@
 import { faEllipsisV } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Dialog } from '@mui/material';
-import React from 'react';
+import React, { useState } from 'react';
 import ChatSettingsForm from './ChatSettingsForm';
 
 export default function ChatSettingsButton(props) {
+  const [open, setOpen] = useState(false);
+
+  function handleClick() {
+    setOpen(true);
+  }
+
   return (<>
-    <Button>
+    <Button onClick={handleClick}>
       <FontAwesomeIcon icon={faEllipsisV}/>
     </Button>
-    <Dialog>
+    <Dialog open={open}>
       <ChatSettingsForm/>
     </Dialog>
   </>)

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -1,7 +1,8 @@
+import { arrayUnion, getDoc, updateDoc } from '@firebase/firestore';
 import { faCopy, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, DialogTitle, ListItemText, ListSubheader, Stack, TextField } from '@mui/material'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import UserCard from './UserCard';
 
 export default function ChatSettingsForm(props) {
@@ -12,8 +13,23 @@ export default function ChatSettingsForm(props) {
     setConversationData(currentConversationRef.data());
   }, [currentConversationRef])
 
+  const newMemberField = useRef(null);
+
   function refreshConversationData() {
-    setConversationData(currentConversationRef.data());
+    // TODO: Eliminate the need for this by subscribing to conversation
+    // in ChatSystem.js via onSnapshot().
+    getDoc(currentConversationRef.ref).then((conversationSnapshot) => {
+      setConversationData(conversationSnapshot.data());
+    })
+  }
+
+  function handleAddMemberClick() {
+    const newMemberId = newMemberField.current.value;
+    if (!newMemberId) return;
+    
+    updateDoc(currentConversationRef.ref, {
+      members: arrayUnion(newMemberId),
+    }).then(() => {refreshConversationData()})
   }
 
   return(<>
@@ -37,8 +53,9 @@ export default function ChatSettingsForm(props) {
     }
     <Stack direction='row'>
       <TextField  label='Add Member'
+                  inputRef={newMemberField}
                   variant='standard'/>
-      <Button><FontAwesomeIcon icon={faPlus}/></Button>
+      <Button onClick={handleAddMemberClick}><FontAwesomeIcon icon={faPlus}/></Button>
     </Stack>
   </>)
 }

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -1,0 +1,4 @@
+import React from 'react'
+
+export default function ChatSettingsForm(props) {
+}

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -30,5 +30,10 @@ export default function ChatSettingsForm(props) {
                 </ListItemText>)
       })
     }
+    <Stack direction='row'>
+      <TextField  label='Add Member'
+                  variant='standard'/>
+      <Button><FontAwesomeIcon icon={faPlus}/></Button>
+    </Stack>
   </>)
 }

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -1,10 +1,13 @@
-import { DialogTitle } from '@mui/material'
+import { DialogTitle, TextField } from '@mui/material'
 import React from 'react'
 
 export default function ChatSettingsForm(props) {
-
+  const {conversationRef: currentConversationRef} = props;
 
   return(<>
     <DialogTitle>Conversation Settings</DialogTitle>
+    <TextField disabled 
+               label="Conversation ID" 
+               defaultValue={currentConversationRef.id}/>
   </>)
 }

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -25,7 +25,8 @@ export default function ChatSettingsForm(props) {
       <Button><FontAwesomeIcon icon={faCopy}/></Button>
     </Stack>
     <TextField  label='Conversation Name'
-                placeholder={conversationData?.name}/>
+                placeholder={conversationData?.name || 
+                  currentConversationRef.id}/>
     <ListSubheader>Members</ListSubheader>
     {conversationData && 
       conversationData.members.map((memberId) => {

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -1,13 +1,31 @@
-import { DialogTitle, TextField } from '@mui/material'
-import React from 'react'
+import { faCopy, faPlus } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button, DialogTitle, ListItemText, ListSubheader, Stack, TextField } from '@mui/material'
+import React, { useEffect, useState } from 'react'
 
 export default function ChatSettingsForm(props) {
   const {conversationRef: currentConversationRef} = props;
 
+  const [conversationData, setConversationData] = useState(null)
+  useEffect(() => {
+    setConversationData(currentConversationRef.data());
+  }, [currentConversationRef])
+
   return(<>
     <DialogTitle>Conversation Settings</DialogTitle>
-    <TextField disabled 
-               label="Conversation ID" 
-               defaultValue={currentConversationRef.id}/>
+    <Stack direction='row'>
+      <TextField  disabled 
+                  label='Conversation ID' 
+                  defaultValue={currentConversationRef.id}/>
+      <Button><FontAwesomeIcon icon={faCopy}/></Button>
+    </Stack>
+    <TextField  label='Conversation Name'
+                placeholder={conversationData?.name}/>
+    <ListSubheader>Members</ListSubheader>
+    {conversationData && 
+      conversationData.members.map((memberId) => {
+        return <ListItemText key={memberId}>{memberId}</ListItemText>
+      })
+    }
   </>)
 }

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -1,4 +1,10 @@
+import { DialogTitle } from '@mui/material'
 import React from 'react'
 
 export default function ChatSettingsForm(props) {
+
+
+  return(<>
+    <DialogTitle>Conversation Settings</DialogTitle>
+  </>)
 }

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -12,6 +12,10 @@ export default function ChatSettingsForm(props) {
     setConversationData(currentConversationRef.data());
   }, [currentConversationRef])
 
+  function refreshConversationData() {
+    setConversationData(currentConversationRef.data());
+  }
+
   return(<>
     <DialogTitle>Conversation Settings</DialogTitle>
     <Stack direction='row'>

--- a/client/src/components/ChatSettingsForm.js
+++ b/client/src/components/ChatSettingsForm.js
@@ -2,6 +2,7 @@ import { faCopy, faPlus } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, DialogTitle, ListItemText, ListSubheader, Stack, TextField } from '@mui/material'
 import React, { useEffect, useState } from 'react'
+import UserCard from './UserCard';
 
 export default function ChatSettingsForm(props) {
   const {conversationRef: currentConversationRef} = props;
@@ -24,7 +25,9 @@ export default function ChatSettingsForm(props) {
     <ListSubheader>Members</ListSubheader>
     {conversationData && 
       conversationData.members.map((memberId) => {
-        return <ListItemText key={memberId}>{memberId}</ListItemText>
+        return  (<ListItemText key={memberId}>
+                  <UserCard uid={memberId}/>
+                </ListItemText>)
       })
     }
   </>)

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -4,6 +4,7 @@ import { db } from "../firebaseInitialize";
 import { newConversation } from "../firestoreData";
 import ChatInput from "./ChatInput";
 import ChatLog from "./ChatLog";
+import ChatOptions from "./ChatOptions";
 import ChatSelector from "./ChatSelector";
 
 export function ChatSystem() {
@@ -38,6 +39,7 @@ export function ChatSystem() {
   return (
     <div>
       <ChatSelector onChange={handleConversationChange} conversationRef={currentConversationRef}/>
+      <ChatOptions></ChatOptions>
       <ChatLog conversationRef={currentConversationRef}/>
       <ChatInput conversationRef={currentConversationRef}/>
     </div>

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -4,7 +4,7 @@ import { db } from "../firebaseInitialize";
 import { newConversation } from "../firestoreData";
 import ChatInput from "./ChatInput";
 import ChatLog from "./ChatLog";
-import ChatOptions from "./ChatOptions";
+import ChatSettingsButton from "./ChatSettingsButton";
 import ChatSelector from "./ChatSelector";
 
 export function ChatSystem() {
@@ -39,7 +39,7 @@ export function ChatSystem() {
   return (
     <div>
       <ChatSelector onChange={handleConversationChange} conversationRef={currentConversationRef}/>
-      <ChatOptions></ChatOptions>
+      <ChatSettingsButton></ChatSettingsButton>
       <ChatLog conversationRef={currentConversationRef}/>
       <ChatInput conversationRef={currentConversationRef}/>
     </div>

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -1,13 +1,16 @@
 import { collection, doc, getDoc, getDocs, limit, query, setDoc } from "@firebase/firestore";
 import { useEffect, useState } from "react";
-import { db } from "../firebaseInitialize";
+import { auth, db } from "../firebaseInitialize";
 import { newConversation } from "../firestoreData";
 import ChatInput from "./ChatInput";
 import ChatLog from "./ChatLog";
 import ChatSettingsButton from "./ChatSettingsButton";
 import ChatSelector from "./ChatSelector";
+import { useAuthState } from "react-firebase-hooks/auth";
 
 export function ChatSystem() {
+  const[user] = useAuthState(auth);
+
   const [currentConversationRef, setConversationRef] = useState(null);
   // Fetch the initial conversation.
   useEffect(() => {
@@ -24,8 +27,9 @@ export function ChatSystem() {
       if (docSnap.exists()) {
         setConversationRef(docSnap);
       } else { // Add the conversation to the DB
-        const newConversationData = newConversation();
         const newDocRef = doc(db, "conversations", newConversationId);
+        const newConversationData = newConversation();
+        newConversationData.members.push(user.uid)
         setDoc(newDocRef, newConversationData);
         setConversationRef(newDocRef);
       }

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -1,4 +1,4 @@
-import { collection, doc, getDoc, getDocs, limit, query, setDoc } from "@firebase/firestore";
+import { collection, doc, getDoc, getDocs, limit, query, setDoc, where } from "@firebase/firestore";
 import { useEffect, useState } from "react";
 import { auth, db } from "../firebaseInitialize";
 import { newConversation } from "../firestoreData";
@@ -18,7 +18,9 @@ export function ChatSystem() {
   const [currentConversationRef, setConversationRef] = useState(null);
   // Fetch the initial conversation.
   useEffect(() => {
-    const q = query(collection(db, "conversations"), limit(1));
+    const q = query(collection(db, "conversations"), 
+      limit(1), 
+      where('access', '==', 'public'));
     getDocs(q).then(querySnapshot => {
       // Since query should be limited to 1 result, forEach is just used to access the single result.
       querySnapshot.forEach(doc => setConversationRef(doc));

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -39,7 +39,7 @@ export function ChatSystem() {
   return (
     <div>
       <ChatSelector onChange={handleConversationChange} conversationRef={currentConversationRef}/>
-      <ChatSettingsButton></ChatSettingsButton>
+      <ChatSettingsButton/>
       <ChatLog conversationRef={currentConversationRef}/>
       <ChatInput conversationRef={currentConversationRef}/>
     </div>

--- a/client/src/components/ChatSystem.js
+++ b/client/src/components/ChatSystem.js
@@ -39,7 +39,7 @@ export function ChatSystem() {
   return (
     <div>
       <ChatSelector onChange={handleConversationChange} conversationRef={currentConversationRef}/>
-      <ChatSettingsButton/>
+      <ChatSettingsButton conversationRef={currentConversationRef}/>
       <ChatLog conversationRef={currentConversationRef}/>
       <ChatInput conversationRef={currentConversationRef}/>
     </div>

--- a/client/src/components/UserCard.js
+++ b/client/src/components/UserCard.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useAsyncState } from '../util/CustomReactHooks';
+import { fetchUsername } from './ChatBubble';
+
+export default function UserCard(props) {
+  const {uid} = props;
+  
+  const [username] = useAsyncState(fetchUsername(uid));
+
+  return (<>
+    {username}
+  </>)
+}

--- a/client/src/util/CustomReactHooks.js
+++ b/client/src/util/CustomReactHooks.js
@@ -1,0 +1,12 @@
+import { useEffect, useState } from "react";
+
+export function useAsyncState(promise, dependencies = []) {
+  const [value, setValue] = useState(null);
+  useEffect(() => {
+    promise.then((resolve) => {
+      setValue(resolve);
+    })
+  }, [promise, ...dependencies])
+
+  return [value, setValue];
+}


### PR DESCRIPTION
Alongside some security rules added to Firestore, this PR ensures that only members of a conversation have access to it (or if the conversation has 'public' access). Members can be added via the new ChatSettings Dialog.

![image](https://user-images.githubusercontent.com/44207690/161829908-94fa6ffb-65f2-4373-a363-3b044d4b0cb3.png)

Members can be added via the new ChatSettings Dialog.

![image](https://user-images.githubusercontent.com/44207690/161830343-71c0e8c6-afe7-43e3-a98f-7e3f6ebe49a4.png)

TODO:
* Autocomplete available conversations in the conversation selector.
* Ability to add members by username rather than uid.
* Autocomplete on Add Member field in the Chat Settings.
* Automatically add second member when a new conversation is created via a targeted user.
* Add functionality to the copy button for ConversationId, and the Change Name field under ChatSettings.